### PR TITLE
fix conversion error for non-ascii filenames under python 2.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/src/dee/application.py
+++ b/src/dee/application.py
@@ -448,7 +448,7 @@ class Application(object):
         for path in xdg_data_dirs:
             path = os.path.join(path, "applications")
             logger.debug("Loading desktop entries from %s" % path)
-            for desktop_file in glob.glob(os.path.join(path, "*.desktop")):
+            for desktop_file in glob.glob(os.path.join(path, u'*.desktop')):
                 #logger.debug(desktop_file)
                 try:
                     entry = Entry(desktop_file)


### PR DESCRIPTION
fix for issue https://github.com/MicahCarrick/desktop-entry-editor/issues/9
unhandled exception error under python 2.7 when ~/.local/share/applications/ contains *.desktop files with non-ASCII characters.
